### PR TITLE
Hotfix for driverdle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@ sitemap.xml
 
 # AUTO-GENERATE BY MOTORSPORTDB
 cards.json
+driverdle.json
 /games/
 /proposal/


### PR DESCRIPTION
This pull request updates the logic for selecting valid drivers and enhances the functionality of the `getDriverOfToday.php` script by adding filtering criteria and caching today's driver data. The changes improve the reliability and efficiency of the driver selection process while ensuring the daily driver data is persisted and reused.

### Driver Selection Enhancements:

* Added `hasAtLeast20Races()` function to filter drivers based on participation in at least 30 races across seasons. (`assets/php/games/driverdle/getDriverOfToday.php`)
* Added `isActiveOrLastYear()` function to ensure drivers are active in the current or previous year. (`assets/php/games/driverdle/getDriverOfToday.php`)
* Updated `getAllDrivers()` function to apply the new filtering criteria using the above functions, ensuring only valid drivers are returned. (`assets/php/games/driverdle/getDriverOfToday.php`)

### Daily Driver Caching:

* Modified `getDailyDriver()` to include the current date in the response and save the daily driver data to a `driverdle.json` file at the web root. (`assets/php/games/driverdle/getDriverOfToday.php`)
* Added logic to check if `driverdle.json` exists and matches today's date. If valid, the cached data is returned to avoid redundant processing. (`assets/php/games/driverdle/getDriverOfToday.php`)